### PR TITLE
docs: add demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 This contains everything you need to run your app locally.
 
+## Demo
+
+![App demo](https://placehold.co/600x400?text=App%20demo)
+
+Introduce un personaje histórico → genera línea real → explora divergencias.
+
+- [Video demo](https://example.com/demo.mp4)
+- [GIF demo](https://example.com/demo.gif)
+
 View your app in AI Studio: https://ai.studio/apps/drive/1xe_qn3mbeTn8-kGWehlBWvAD47oKQyTb
 
 ## Run Locally

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@google/genai": "^1.17.0",


### PR DESCRIPTION
## Summary
- add demo section with screenshot and usage flow
- add placeholder links for video and gif demos
- run vitest in ci mode
- replace local demo image with external placeholder to avoid binary files

## Testing
- `npm test` *(fails: Error loading Blas de Lezo biography; module "vitest-axe" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4ae3ed8c8331b5de5154dd341464