### PR TITLE
Use localized waiting messages

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -64,18 +64,6 @@ const App: React.FC = () => {
     const [language, setLanguage] = useState<Language>('es');
     const t = translations[language];
 
-    const waitingMessages = {
-        real: [
-            'Viajando al pasado para recuperar datos perdidos…',
-            'Consultando archivos polvorientos de la historia…',
-            'Convenciendo a cronistas gruñones para que hablen…',
-        ],
-        alternative: [
-            'Abriendo portales al multiverso…',
-            'Interrogando a viajeros temporales indiscretos…',
-            'Negociando con realidades paralelas…',
-        ],
-    };
     const [loadingMessage, setLoadingMessage] = useState('');
 
     useEffect(() => {
@@ -85,14 +73,14 @@ const App: React.FC = () => {
             return;
         }
         let index = 0;
-        const messages = waitingMessages[active];
+        const messages = t.waitingMessages[active];
         setLoadingMessage(messages[0]);
         const interval = setInterval(() => {
             index = (index + 1) % messages.length;
             setLoadingMessage(messages[index]);
         }, 3000);
         return () => clearInterval(interval);
-    }, [isLoading, isAlternativeLoading]);
+    }, [isLoading, isAlternativeLoading, t]);
 
     useEffect(() => {
         if (activeAlternativeTimeline) {

--- a/i18n.tsx
+++ b/i18n.tsx
@@ -23,6 +23,10 @@ export interface Translation {
   imageProgress: (current: number, total: number) => string;
   switchToEnglish: string;
   switchToSpanish: string;
+  waitingMessages: {
+    real: string[];
+    alternative: string[];
+  };
 }
 
 export const translations: Record<Language, Translation> = {
@@ -60,6 +64,18 @@ export const translations: Record<Language, Translation> = {
     imageProgress: (current, total) => `Imágenes generadas: ${current} de ${total}`,
     switchToEnglish: 'Cambiar a inglés',
     switchToSpanish: 'Cambiar a español',
+    waitingMessages: {
+      real: [
+        'Viajando al pasado para recuperar datos perdidos…',
+        'Consultando archivos polvorientos de la historia…',
+        'Convenciendo a cronistas gruñones para que hablen…',
+      ],
+      alternative: [
+        'Abriendo portales al multiverso…',
+        'Interrogando a viajeros temporales indiscretos…',
+        'Negociando con realidades paralelas…',
+      ],
+    },
   },
   en: {
     appTitle: 'Counterfactual Chronicler',
@@ -95,5 +111,17 @@ export const translations: Record<Language, Translation> = {
     imageProgress: (current, total) => `Images generated: ${current} of ${total}`,
     switchToEnglish: 'Switch to English',
     switchToSpanish: 'Switch to Spanish',
+    waitingMessages: {
+      real: [
+        'Traveling to the past to retrieve lost data…',
+        'Consulting dust-covered historical archives…',
+        'Coaxing grumpy chroniclers to talk…',
+      ],
+      alternative: [
+        'Opening portals to the multiverse…',
+        'Questioning indiscreet time travelers…',
+        'Negotiating with parallel realities…',
+      ],
+    },
   },
 };


### PR DESCRIPTION
## Summary
- add translated `waitingMessages` for real and alternative timeline loading states
- use translation-sourced waiting messages in `App`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd559ada2c8331aae8d64137ba705f