### PR TITLE
docs: add JSDoc for Gemini services

### DIFF
--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -8,6 +8,16 @@ import { timelineSchema, alternativeTimelineSchema } from './geminiSchemas';
 const ai = new GoogleGenAI({ apiKey: API_KEY });
 
 let blasBiographyPromise: Promise<string> | null = null;
+
+/**
+ * Fetches the biography of Blas de Lezo from a remote source.
+ * The result is cached after the first successful request to avoid
+ * repeated network calls on subsequent invocations.
+ *
+ * @returns Promise resolving to the biography text.
+ * @throws {Error} If the biography cannot be retrieved.
+ * @internal
+ */
 const getBlasDeLezoBiography = async (): Promise<string> => {
     if (!blasBiographyPromise) {
         blasBiographyPromise = fetch(BLAS_DE_LEZO_BIOGRAPHY_URL).then(res => {
@@ -22,6 +32,15 @@ const getBlasDeLezoBiography = async (): Promise<string> => {
 
 
 
+/**
+ * Generates a historical timeline for the provided character using the Gemini API.
+ * Additional RAG context is injected when the character is Blas de Lezo.
+ *
+ * @param character Name of the historical character to analyse.
+ * @param lang Language for the returned titles and descriptions.
+ * @returns A promise resolving to the complete timeline data structure.
+ * @throws {Error} If the Gemini API request fails or returns malformed data.
+ */
 export const generateTimelineData = async (character: string, lang: Language): Promise<FullTimelineData> => {
     let ragContext = "Usa tu conocimiento interno sobre la biografía del [PERSONAJE_HISTORICO] como fuente de verdad primaria para esta tarea.";
 
@@ -60,6 +79,19 @@ export const generateTimelineData = async (character: string, lang: Language): P
     }
 };
 
+/**
+ * Executes an asynchronous function with automatic retries.
+ * Each retry waits for the specified delay and doubles the delay
+ * on every subsequent attempt (exponential backoff).
+ *
+ * @template T
+ * @param fn Function to execute.
+ * @param retries Number of retry attempts before giving up. Defaults to 3.
+ * @param delay Initial delay in milliseconds before retrying. Defaults to 1000.
+ * @returns The resolved value from the provided function.
+ * @throws Propagates the error from {@link fn} after all retries fail.
+ * @internal
+ */
 const withRetry = async <T>(fn: () => Promise<T>, retries = 3, delay = 1000): Promise<T> => {
     try {
         return await fn();
@@ -74,6 +106,17 @@ const withRetry = async <T>(fn: () => Promise<T>, retries = 3, delay = 1000): Pr
     }
 };
 
+/**
+ * Generates a new image or edits an existing one using Gemini image models.
+ * Provide only a prompt to create a fresh image, or include a base64 data URL
+ * to apply edits to an existing JPEG. Prompts should succinctly describe the
+ * desired scene and style (e.g., "17th-century naval battle, oil painting").
+ *
+ * @param prompt Text description of the desired image.
+ * @param base64Image Optional existing image encoded as a `data:image/jpeg;base64,...` URL.
+ * @returns Promise resolving to a base64-encoded JPEG data URL.
+ * @throws {Error} If no image is produced or the Gemini API request fails.
+ */
 export const generateOrEditImage = async (prompt: string, base64Image?: string): Promise<string> => {
     return withRetry(async () => {
         if (base64Image) {
@@ -122,6 +165,17 @@ export const generateOrEditImage = async (prompt: string, base64Image?: string):
 };
 
 
+/**
+ * Creates an alternative timeline based on a divergence point and the last
+ * known real event for a character.
+ *
+ * @param character Name of the historical figure.
+ * @param divergencePoint Divergence question and selected option.
+ * @param lastRealEvent The last verified event from the real timeline.
+ * @param lang Language for the resulting events.
+ * @returns Promise resolving to a list of alternative timeline events.
+ * @throws {Error} If the Gemini API request fails or returns malformed data.
+ */
 export const generateAlternativeTimeline = async (character: string, divergencePoint: DivergencePoint, lastRealEvent: TimelineEvent, lang: Language): Promise<AlternativeTimelineEvent[]> => {
     const prompt = `
         ROL: Eres un "Cronista Contrafactual", un experto en historia y narrativa.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
       ]
     },
     "allowImportingTsExtensions": true,
-    "noEmit": true
+    "noEmit": true,
+    "stripInternal": true
   }
 }


### PR DESCRIPTION
## Summary
- document Gemini service helpers with parameter/return/error details
- describe caching, retry, and image prompt usage in docs
- enable `stripInternal` to drop internal declarations from generated docs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd58d618c08331a1b5a45dcd27240c