### PR TITLE
feat: apply parchment color scheme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -144,11 +144,11 @@ const App: React.FC = () => {
     const imageCardProps = { images, imageLoading };
 
     return (
-        <div className="min-h-screen bg-gray-900 bg-gradient-to-br from-gray-900 via-gray-900 to-cyan-900/40 text-white font-sans relative">
+        <div className="min-h-screen bg-parchment bg-gradient-to-br from-parchment via-parchment to-accent/40 text-sepia font-sans relative">
             <div className="absolute top-4 right-4">
                 <button
                     onClick={() => setLanguage(prev => prev === 'es' ? 'en' : 'es')}
-                    className="px-3 py-1 bg-gray-800 rounded text-sm border border-gray-600 hover:border-cyan-400 transition-colors"
+                    className="px-3 py-1 bg-parchment rounded text-sm border border-gray-600 hover:border-accent transition-colors"
                     aria-label={language === 'es' ? t.switchToEnglish : t.switchToSpanish}
                 >
                     <img
@@ -164,11 +164,11 @@ const App: React.FC = () => {
                 {isLoading && (
                     <div className="mt-12 text-center" role="status" aria-live="polite">
                         <Spinner size="lg" label={t.loading} />
-                        <p className="mt-4 text-gray-300 italic">{loadingMessage}</p>
+                        <p className="mt-4 text-sepia italic">{loadingMessage}</p>
                         {imageProgress && (
                             <>
                                 <progress value={imageProgress.current} max={imageProgress.total} className="mt-4 w-64" />
-                                <p className="mt-2 text-gray-300">{t.imageProgress(imageProgress.current, imageProgress.total)}</p>
+                                <p className="mt-2 text-sepia">{t.imageProgress(imageProgress.current, imageProgress.total)}</p>
                             </>
                         )}
                     </div>
@@ -182,7 +182,7 @@ const App: React.FC = () => {
                             id="real-timeline"
                             className={activeAlternativeTimeline ? 'opacity-40 transition-opacity' : ''}
                         >
-                            <h2 className="text-4xl font-bold text-center mb-12 text-transparent bg-clip-text bg-gradient-to-r from-gray-200 to-cyan-300 flex items-center justify-center gap-3"><ClockIcon className="w-8 h-8"/> {t.realTimeline}</h2>
+                            <h2 className="text-4xl font-bold text-center mb-12 text-transparent bg-clip-text bg-gradient-to-r from-sepia to-accent flex items-center justify-center gap-3"><ClockIcon className="w-8 h-8"/> {t.realTimeline}</h2>
                             <div className="relative flex flex-col items-center gap-12">
                                 <TimelineNode isLast={!activeAlternativeTimeline} />
                                 {timelineData.linea_temporal_real.map((event, index) => (
@@ -203,11 +203,11 @@ const App: React.FC = () => {
                         {isAlternativeLoading && (
                             <div className="mt-12 text-center" role="status" aria-live="polite">
                                 <Spinner size="lg" label={t.loading} />
-                                <p className="mt-4 text-gray-300 italic">{loadingMessage}</p>
+                                <p className="mt-4 text-sepia italic">{loadingMessage}</p>
                                 {imageProgress && (
                                     <>
                                         <progress value={imageProgress.current} max={imageProgress.total} className="mt-4 w-64" />
-                                        <p className="mt-2 text-gray-300">{t.imageProgress(imageProgress.current, imageProgress.total)}</p>
+                                        <p className="mt-2 text-sepia">{t.imageProgress(imageProgress.current, imageProgress.total)}</p>
                                     </>
                                 )}
                             </div>
@@ -215,7 +215,7 @@ const App: React.FC = () => {
 
                         {activeAlternativeTimeline && (
                             <section id="alternative-timeline" className="mt-16 animate-fade-in">
-                                <h2 className="text-4xl font-bold text-center mb-12 text-transparent bg-clip-text bg-gradient-to-r from-yellow-200 to-yellow-400 flex items-center justify-center gap-3"><HistoryIcon className="w-8 h-8"/> {t.alternativeTimeline}</h2>
+                                <h2 className="text-4xl font-bold text-center mb-12 text-transparent bg-clip-text bg-gradient-to-r from-accent to-sepia flex items-center justify-center gap-3"><HistoryIcon className="w-8 h-8"/> {t.alternativeTimeline}</h2>
                                 <div className="relative flex flex-col items-center gap-12">
                                     <TimelineNode isLast={true} />
                                     {activeAlternativeTimeline.map((event, index) => (

--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -42,9 +42,9 @@ const EventCard: React.FC<EventCardProps> = ({
             className={`relative group w-full lg:w-2/3 mx-auto p-4 ${className}`}
             style={style}
         >
-            <div className="bg-gray-800/30 backdrop-blur-md rounded-xl shadow-lg border border-gray-700/50 p-6 transition-all duration-300 hover:border-cyan-400/50 hover:shadow-cyan-500/10">
+            <div className="bg-parchment/30 backdrop-blur-md rounded-xl shadow-lg border border-gray-700/50 p-6 transition-all duration-300 hover:border-accent/50 hover:shadow-accent/10">
                 <h3 className="text-2xl font-bold text-cyan-300 mb-2">{title}</h3>
-                <p className="text-gray-300 mb-4">{event.descripcion_corta}</p>
+                <p className="text-sepia mb-4">{event.descripcion_corta}</p>
                 <ImageCard
                     eventId={event.id}
                     alt={t.imageAlt(title)}
@@ -55,7 +55,7 @@ const EventCard: React.FC<EventCardProps> = ({
                 {divergence && !isAlternative && (
                     <div className="mt-6 p-4 border-t-2 border-dashed border-gray-600">
                         <h4 className="text-lg font-semibold text-yellow-300 mb-3 flex items-center"><BranchIcon className="w-5 h-5 mr-2"/> {t.divergenceTitle}</h4>
-                        <p className="italic text-gray-400 mb-4">"{divergence.titulo_pregunta}"</p>
+                        <p className="italic text-sepia mb-4">"{divergence.titulo_pregunta}"</p>
                         <button onClick={() => onShowAlternative(divergence)} className="px-4 py-2 bg-yellow-500/20 text-yellow-300 border border-yellow-400 rounded-lg hover:bg-yellow-500/40 transition-colors">
                             {t.exploreAlternative}
                         </button>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -20,26 +20,26 @@ const HeroSection: React.FC<{ onGenerate: (character: string) => void; isLoading
     };
 
     return (
-        <div className="text-center p-8 bg-gray-900/50 rounded-lg shadow-2xl shadow-cyan-500/10 backdrop-blur-sm">
+        <div className="text-center p-8 bg-parchment/50 rounded-lg shadow-2xl shadow-accent/10 backdrop-blur-sm">
             <h1 className="text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-teal-200 mb-4">{t.appTitle}</h1>
-            <p className="text-lg text-gray-300 mb-6">{t.appDescription}</p>
+            <p className="text-lg text-sepia mb-6">{t.appDescription}</p>
 
-            <div className="text-left max-w-2xl mx-auto text-gray-300 mb-8">
+            <div className="text-left max-w-2xl mx-auto text-sepia mb-8">
                 <p className="mb-3 font-semibold">{t.stepsIntro}</p>
                 <ol className="list-decimal list-inside space-y-2">
-                    <li className="bg-gray-800/40 border-l-4 border-cyan-500 p-3">
+                    <li className="bg-parchment/40 border-l-4 border-accent p-3">
                         <div className="flex items-start gap-2">
                             <ClockIcon className="w-5 h-5 text-cyan-400 mt-1" />
                             <span>{t.step1}</span>
                         </div>
                     </li>
-                    <li className="bg-gray-800/40 border-l-4 border-cyan-500 p-3">
+                    <li className="bg-parchment/40 border-l-4 border-accent p-3">
                         <div className="flex items-start gap-2">
                             <BranchIcon className="w-5 h-5 text-cyan-400 mt-1" />
                             <span>{t.step2}</span>
                         </div>
                     </li>
-                    <li className="bg-gray-800/40 border-l-4 border-cyan-500 p-3">
+                    <li className="bg-parchment/40 border-l-4 border-accent p-3">
                         <div className="flex items-start gap-2">
                             <HistoryIcon className="w-5 h-5 text-cyan-400 mt-1" />
                             <span>{t.step3}</span>
@@ -55,7 +55,7 @@ const HeroSection: React.FC<{ onGenerate: (character: string) => void; isLoading
                     onChange={(e) => setCharacter(e.target.value)}
                     placeholder={t.placeholder}
                     aria-label={t.placeholder}
-                    className="w-full sm:w-80 px-4 py-3 bg-gray-800/70 border-2 border-gray-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-cyan-400 focus:border-cyan-400 transition duration-300"
+                    className="w-full sm:w-80 px-4 py-3 bg-parchment/70 border-2 border-gray-600 rounded-lg text-sepia focus:outline-none focus:ring-2 focus:ring-accent focus:border-accent transition duration-300"
                     disabled={isLoading}
                 />
                 <button

--- a/components/TimelineNode.tsx
+++ b/components/TimelineNode.tsx
@@ -5,9 +5,9 @@ import React from 'react';
  * @param props.isLast - Indicates whether this node is the final one.
  */
 const TimelineNode: React.FC<{ isLast?: boolean }> = ({ isLast = false }) => (
-    <div className="absolute left-1/2 -ml-[1px] top-12 w-0.5 h-full bg-gray-700">
-        <div className="absolute left-1/2 -ml-2 top-0 w-4 h-4 rounded-full bg-gray-700 border-2 border-cyan-400"></div>
-        {isLast && <div className="absolute left-1/2 -ml-2 bottom-0 w-4 h-4 rounded-full bg-gray-700 border-2 border-cyan-400"></div>}
+    <div className="absolute left-1/2 -ml-[1px] top-12 w-0.5 h-full bg-accent">
+        <div className="absolute left-1/2 -ml-2 top-0 w-4 h-4 rounded-full bg-parchment border-2 border-accent"></div>
+        {isLast && <div className="absolute left-1/2 -ml-2 bottom-0 w-4 h-4 rounded-full bg-parchment border-2 border-accent"></div>}
     </div>
 );
 

--- a/index.html
+++ b/index.html
@@ -8,6 +8,19 @@
     <meta property="og:title" content="Cronista Contrafactual" />
     <meta property="og:description" content="Explora líneas históricas reales y alternativas generadas por IA." />
     <title>Cronista Contrafactual</title>
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              parchment: "#f7f1d7",
+              sepia: "#704214",
+              accent: "#c19a6b"
+            }
+          }
+        }
+      };
+    </script>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       @keyframes slide-up {
@@ -38,7 +51,7 @@
 }
 </script>
 </head>
-  <body class="bg-gray-900 text-gray-100">
+  <body class="bg-parchment text-sepia">
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- define parchment, sepia and accent colors in Tailwind config
- swap gray backgrounds and cyan borders for the new palette across key components

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5b0e62d48331b5891df244089a5e