### PR TITLE
feat: add custom fonts

### DIFF
--- a/components/EventCard.tsx
+++ b/components/EventCard.tsx
@@ -43,8 +43,8 @@ const EventCard: React.FC<EventCardProps> = ({
             style={style}
         >
             <div className="bg-parchment/30 backdrop-blur-md rounded-xl shadow-lg border border-gray-700/50 p-6 transition-all duration-300 hover:border-accent/50 hover:shadow-accent/10">
-                <h3 className="text-2xl font-bold text-cyan-300 mb-2">{title}</h3>
-                <p className="text-sepia mb-4">{event.descripcion_corta}</p>
+                <h3 className="text-2xl font-serif font-bold text-cyan-300 mb-2">{title}</h3>
+                <p className="font-sans text-sepia mb-4">{event.descripcion_corta}</p>
                 <ImageCard
                     eventId={event.id}
                     alt={t.imageAlt(title)}
@@ -54,8 +54,8 @@ const EventCard: React.FC<EventCardProps> = ({
                 />
                 {divergence && !isAlternative && (
                     <div className="mt-6 p-4 border-t-2 border-dashed border-gray-600">
-                        <h4 className="text-lg font-semibold text-yellow-300 mb-3 flex items-center"><BranchIcon className="w-5 h-5 mr-2"/> {t.divergenceTitle}</h4>
-                        <p className="italic text-sepia mb-4">"{divergence.titulo_pregunta}"</p>
+                        <h4 className="text-lg font-serif font-semibold text-yellow-300 mb-3 flex items-center"><BranchIcon className="w-5 h-5 mr-2"/> {t.divergenceTitle}</h4>
+                        <p className="font-sans italic text-sepia mb-4">"{divergence.titulo_pregunta}"</p>
                         <button onClick={() => onShowAlternative(divergence)} className="px-4 py-2 bg-yellow-500/20 text-yellow-300 border border-yellow-400 rounded-lg hover:bg-yellow-500/40 transition-colors">
                             {t.exploreAlternative}
                         </button>

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -21,11 +21,11 @@ const HeroSection: React.FC<{ onGenerate: (character: string) => void; isLoading
 
     return (
         <div className="text-center p-8 bg-parchment/50 rounded-lg shadow-2xl shadow-accent/10 backdrop-blur-sm">
-            <h1 className="text-5xl font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-teal-200 mb-4">{t.appTitle}</h1>
-            <p className="text-lg text-sepia mb-6">{t.appDescription}</p>
+            <h1 className="text-5xl font-serif font-bold text-transparent bg-clip-text bg-gradient-to-r from-cyan-400 to-teal-200 mb-4">{t.appTitle}</h1>
+            <p className="font-sans text-lg text-sepia mb-6">{t.appDescription}</p>
 
-            <div className="text-left max-w-2xl mx-auto text-sepia mb-8">
-                <p className="mb-3 font-semibold">{t.stepsIntro}</p>
+            <div className="font-sans text-left max-w-2xl mx-auto text-sepia mb-8">
+                <p className="mb-3 font-sans font-semibold">{t.stepsIntro}</p>
                 <ol className="list-decimal list-inside space-y-2">
                     <li className="bg-parchment/40 border-l-4 border-accent p-3">
                         <div className="flex items-start gap-2">

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <meta property="og:title" content="Cronista Contrafactual" />
     <meta property="og:description" content="Explora líneas históricas reales y alternativas generadas por IA." />
     <title>Cronista Contrafactual</title>
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Inter:wght@400;700&display=swap" rel="stylesheet">
     <script>
       tailwind.config = {
         theme: {
@@ -16,6 +17,10 @@
               parchment: "#f7f1d7",
               sepia: "#704214",
               accent: "#c19a6b"
+            },
+            fontFamily: {
+              serif: ['"Playfair Display"', 'serif'],
+              sans: ['Inter', 'sans-serif']
             }
           }
         }


### PR DESCRIPTION
## Summary
- add Google Fonts and Tailwind font family config
- use Playfair Display for headings and Inter for text

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5c4aa1e083318fe86fd720707cbd